### PR TITLE
fix: give default value to `options` arg

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -22,7 +22,7 @@ function noRobots() {
  * @param {any} eleventyConfig
  * @param {EleventyPluginNoRobotsOptions} options
  */
-module.exports = (eleventyConfig, options) => {
+module.exports = (eleventyConfig, options = {}) => {
 	let count = 0;
 
 	eleventyConfig.addShortcode("noRobots", () => {


### PR DESCRIPTION
Thank you for making this plugin! I've added it to my site and it works great. I found one small issue when the plugin receives no options (or in other words when `options` is undefined).

I'm running v2 of 11ty on my site.